### PR TITLE
ODSP-347 Fix croissant export via ror api version fix

### DIFF
--- a/utils/dataverse/patches/external_vocabularies/update.sh
+++ b/utils/dataverse/patches/external_vocabularies/update.sh
@@ -30,10 +30,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CURRENT_DIR="$(pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
+# script files to be copied to the dataverse container
 echo "Updating external vocabularies: Adding the files missing for ROR..."
 
 docker cp ../../../../utils/external_vocabularies/cvocutils.js "$DATAVERSE_CONTAINER":/opt/payara/deployments/dataverse/custom/cvocutils.js
 docker cp ../../../../utils/external_vocabularies/ror.js "$DATAVERSE_CONTAINER":/opt/payara/deployments/dataverse/custom/ror.js
+
+# cvoc configuration changes must also be applied
+echo "Updating external vocabularies: Adding the cvocconf.json file and updating the cvoc configuration in dataverse..."
+docker cp ../../../../utils/external_vocabularies/cvocconf.json "$DATAVERSE_CONTAINER":/opt/payara/cvocconf.json
+docker exec "$DATAVERSE_CONTAINER" curl -X PUT --upload-file cvocconf.json http://localhost:8080/api/admin/settings/:CVocConf
 
 echo "External vocabularies update complete!"
 echo "The ROR will now be visible as links in the dataset metadata"

--- a/utils/external_vocabularies/cvocconf.json
+++ b/utils/external_vocabularies/cvocconf.json
@@ -504,7 +504,7 @@
             "/custom/cvocutils.js"
         ],
         "protocol": "ror",
-        "retrieval-uri": "https://api.ror.org/organizations/{0}",
+        "retrieval-uri": "https://api.ror.org/v1/organizations/{0}",
         "allow-free-text": true,
         "prefix": "https://ror.org/",
         "managed-fields": {},


### PR DESCRIPTION
Fixes the URL for the ROR API; should vor the versions of Datvesre that we have <6.9 be explicitly `v1`. 

Run the external_vocabularies upgrade script; for the dev_dataverse it will be this: 
```
utils/dataverse/patches/external_vocabularies/update.sh dev_dataverse
```
 


