### PR TITLE
fix: resolved issue with robots.txt and copying it

### DIFF
--- a/utils/dataverse/fix_robots_txt.sh
+++ b/utils/dataverse/fix_robots_txt.sh
@@ -21,7 +21,7 @@ cd "$SCRIPT_DIR" || exit 1
 
 # Only allow some crawling on production 
 # Nothing special on the staging server, so we can just use the dev.robots.txt file
-if [ "$HOSTNAME" = "odissei.nl" ]; then
+if [ "$HOSTNAME" = "odissei01" ]; then
   echo "Copying production robots.txt file to dataverse container"
   docker cp robots-txt/prod.robots.txt "$dataverse_container_name":/opt/payara/deployments/dataverse/robots.txt
 else

--- a/utils/dataverse/robots-txt/prod.robots.txt
+++ b/utils/dataverse/robots-txt/prod.robots.txt
@@ -10,10 +10,10 @@ Allow: /api/datasets/:persistentId/thumbnail
 Allow: /javax.faces.resource/images/
 Disallow: /*;jsessionid
 Disallow: /dataset.xhtml;jsessionid=
+Disallow: /dataset.xhtml?jsessionid=
 Disallow: /javax.faces.resource/.xhtml;jsessionid=
-Disallow: /api/datasets/:persistentId/thumbnaill;jsessionid=
+Disallow: /api/datasets/:persistentId/thumbnail;jsessionid=
 Disallow: /dataverse/*?q
 Disallow: /dataverse/*/search
-Disallow: /
 Crawl-delay: 10
-sitemap: https://portal.odissei.nl/sitemap.xml
+Sitemap: https://portal.odissei.nl/sitemap.xml


### PR DESCRIPTION
The issue was indeed what Paul suspected. The `$HOSTNAME` was likely not properly set during the upgrade, as it expects `odissei.nl` whilst the machine is named `odissei01`. 

I have changed this in `fix_robots_txt.sh`, as matching the machine name directly seemed the safer approach for now. It may be worth considering, in future, adding a flag to allow the script to distinguish between production and non-production environments.

The change also resolves several minor issues within `robots.txt`, including typos, duplicate lines, and inconsistencies.