### PR TITLE
ODSP-390: Fix sitemap

### DIFF
--- a/install_sitemap_crontab.sh
+++ b/install_sitemap_crontab.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+ 
+echo "Adding cron job for the Dataverse sitemap generation..."
+
+source .env
+
+# check if DATAVERSE_CONTAINER exists
+if [ -z "$DATAVERSE_CONTAINER" ]; then
+    echo "No dataverse container specified as environment variable; exiting!"
+    exit 1
+else
+    echo "Using dataverse container from environment variable: $DATAVERSE_CONTAINER"
+fi
+
+# print the value of DATAVERSE_CONTAINER into the CRON_JOB variable
+CRON_JOB=$(printf "# dataverse sitemap rebuild
+0 4 * * * docker exec %s curl -X POST http://localhost:8080/api/admin/sitemap" "$DATAVERSE_CONTAINER")
+ 
+# Check if the job already exists
+if crontab -l 2>/dev/null | grep -qF "# dataverse sitemap rebuild"; then
+    echo "Cron job already exists, skipping."
+    exit 0
+fi
+ 
+# Add (append) the job
+(crontab -l 2>/dev/null; echo "$CRON_JOB") | crontab -
+ 
+echo "Cron job installed successfully."

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ run the script that will install the con job that will trigger a generation ever
 ```
 ./install_sitemap_crontab.sh
 ```
-The sitemap is available under via the portal site under `/sitemap/sitemap.xml`. 
+The sitemap should become available under via the portal site under `/sitemap/sitemap.xml`. 
 
 
 ## Cleanup for Commits and Pull Requests

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,15 @@ There are now several 'steps' that need to be done:
 3. Remove the ‘Add Data’ button on the menu bar. 
    Change the root dataverse permissions: From ' Anyone with an account can add a dataverse or dataset' into ‘Anyone adding to this dataverse needs to be given access’. And then the button in the navbar will disappear.
 
+### Sitemap generation
+
+On a server you would like to have the portal sitemap generation working. 
+run the script that will install the con job that will trigger a generation every night:
+```
+./install_sitemap_crontab.sh
+```
+The sitemap is available under via the portal site under `/sitemap/sitemap.xml`. 
+
 
 ## Cleanup for Commits and Pull Requests
 


### PR DESCRIPTION
Added portal sitemap generation cron job installer script. 
The script will add the cron job on the serevr and not the contanier; this has te be run only once. 
`./install_sitemap_crontab.sh`
