### PR TITLE
Added API blocking settings to docker compose file

### DIFF
--- a/dataverse/docker-compose.yml
+++ b/dataverse/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       # These two oai settings are here to get HarvestingServerIT to pass
       dataverse_oai_server_maxidentifiers: "2"
       dataverse_oai_server_maxrecords: "2"
+      DATAVERSE_API_BLOCKED_ENDPOINTS: "api/admin,api/builtin-users"
+      DATAVERSE_API_BLOCKED_POLICY: "localhost-only"
       JVM_ARGS: -Ddataverse.files.storage-driver-id=file1
         -Ddataverse.files.file1.type=file
         -Ddataverse.files.file1.label=Filesystem


### PR DESCRIPTION
Probably we won't use this anymore because we will use the ansible code for upgrading and mainbtenace. But, just to be clear and docuement things, the docker-compose.yml is addapted to fix the API blocking problem. 
