### PR TITLE
Setup with6.9

### DIFF
--- a/dataverse/dot_env
+++ b/dataverse/dot_env
@@ -1,4 +1,5 @@
-APP_IMAGE=gdcc/dataverse:6.6-noble
+#APP_IMAGE=gdcc/dataverse:6.6-noble
+APP_IMAGE=gdcc/dataverse:6.9-noble
 BASE_IMAGE=gdcc/configbaker:unstable
 POSTGRES_VERSION=17
 DATAVERSE_DB_USER=dataverse

--- a/dataverse/dot_env
+++ b/dataverse/dot_env
@@ -1,6 +1,6 @@
-#APP_IMAGE=gdcc/dataverse:6.6-noble
-APP_IMAGE=gdcc/dataverse:6.9-noble
-BASE_IMAGE=gdcc/configbaker:unstable
+# Replaced gdcc/dataverse:6.9-noble with a patched version
+APP_IMAGE=ghcr.io/odissei-data/dataverse:6.9-patch1
+BASE_IMAGE=gdcc/configbaker:6.9-noble
 POSTGRES_VERSION=17
 DATAVERSE_DB_USER=dataverse
 SOLR_VERSION=9.8.0

--- a/setup.sh
+++ b/setup.sh
@@ -113,6 +113,11 @@ echo "--- Setting up dutch translation..."
 sh utils/language_setup.sh "$DATAVERSE_CONTAINER"
 echo "--- Dutch translation setup complete!"
 
+# Dutch switch somehow does not work, temporarily disable it !
+echo "--- Disabling Dutch translation, only English available..."
+docker exec "$DATAVERSE_CONTAINER" curl http://localhost:8080/api/admin/settings/:Languages -X PUT -d '[{"locale":"en","title":"English"}]'
+echo "--- Dutch translation disabled!"
+
 # Copy adjusted robots.txt
 echo "--- Copying adjusted robots.txt..."
 sh utils/dataverse/fix_robots_txt.sh "$DATAVERSE_CONTAINER"

--- a/utils/solr/schema.xml
+++ b/utils/solr/schema.xml
@@ -157,7 +157,8 @@
     <field name="dvSubject" type="string" stored="true" indexed="true" multiValued="true"/>
 
     <field name="publicationStatus" type="string" stored="true" indexed="true" multiValued="true"/>
-    <field name="externalStatus" type="string" stored="true" indexed="true" multiValued="false"/>
+    <field name="curationStatus" type="string" stored="true" indexed="true" multiValued="false"/>
+    <field name="curationStatusCreateTime" type="pdate" indexed="true" stored="true"/>
     <field name="embargoEndDate" type="plong" stored="true" indexed="true" multiValued="false"/>
     <field name="retentionEndDate" type="plong" stored="true" indexed="true" multiValued="false"/>
 
@@ -241,6 +242,7 @@
 
     <field name="license" type="string" stored="true" indexed="true" multiValued="false"/>
     <field name="fileCount" type="plong" stored="true" indexed="true" multiValued="false"/>
+    <field name="datasetCount" type="plong" stored="true" indexed="true" multiValued="false"/>
     
     <!--
         METADATA SCHEMA FIELDS

--- a/utils/solr/solrconfig.xml
+++ b/utils/solr/solrconfig.xml
@@ -238,7 +238,7 @@
          have some sort of hard autoCommit to limit the log size.
       -->
     <autoCommit>
-      <maxTime>${solr.autoCommit.maxTime:30000}</maxTime>
+      <maxTime>${solr.autoCommit.maxTime:300000}</maxTime>
       <openSearcher>false</openSearcher>
     </autoCommit>
 


### PR DESCRIPTION
After upgrading to 6.9 (with the ansible playbooks), the setup should spin up a 6.9 so we can test with it. This is needed untill we can use the ansible code to deploy a dev server via Vagrant, which is much better because we do not have to touch our local PC, its all contained so to speak
